### PR TITLE
Remove json file selection from JS linting

### DIFF
--- a/lib/gl_lint/file_selector.rb
+++ b/lib/gl_lint/file_selector.rb
@@ -13,7 +13,7 @@ module GLLint
           # Make certain that schemas are ignored
           rubocop_files.reject! { |f| f.match?(%r{db/.*schema.rb}) }
 
-          prettier_files = selected_files.grep(/\.(js|jsx|json|css)\z/)
+          prettier_files = selected_files.grep(/\.(js|jsx|css)\z/)
         end
 
         { rubocop: rubocop_files, prettier: prettier_files }

--- a/lib/gl_lint/version.rb
+++ b/lib/gl_lint/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GLLint
-  VERSION = '0.4.1'
+  VERSION = '0.5.0'
 end

--- a/lib/gl_lint/version.rb
+++ b/lib/gl_lint/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GLLint
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end


### PR DESCRIPTION
We don't successfully lint json - json files fail linting - so let's remove them.

